### PR TITLE
Update Backend Image v1.0.6

### DIFF
--- a/kustomization.yaml
+++ b/kustomization.yaml
@@ -8,8 +8,8 @@ commonLabels:
   app: todoapp
 images:
 - name: todoapp-backend
-  newName: asia-northeast1-docker.pkg.dev/phu-le-it/todoapp-repository/todoapp-backend
-  newTag: v1.0.9
+  newName: us-east1-docker.pkg.dev/todo-app-377405/todoapp-repository/todoapp-backend
+  newTag: v1.0.6
 - name: todoapp-frontend
   newName: asia-northeast1-docker.pkg.dev/phu-le-it/todoapp-repository/todoapp-frontend
   newTag: v1.0.5


### PR DESCRIPTION
Update Backend Container Image
- New Image Tag: v1.0.6
- Build: [Click Here][1]

[1]: https://github.com/crisphuc/devops-todoapp-backend/actions/runs/4158171731