### PR TITLE
Update Frontend Image v1.0.5

### DIFF
--- a/kustomization.yaml
+++ b/kustomization.yaml
@@ -11,5 +11,5 @@ images:
   newName: asia-northeast1-docker.pkg.dev/phu-le-it/todoapp-repository/todoapp-backend
   newTag: v1.0.9
 - name: todoapp-frontend
-  newName: asia-northeast1-docker.pkg.dev/phu-le-it/todoapp-repository/todoapp-frontend
+  newName: us-east1-docker.pkg.dev/todo-app-377405/todoapp-repository/todoapp-frontend
   newTag: v1.0.5


### PR DESCRIPTION
Update Frontend Container Image
- New Image Tag: v1.0.5
- Build: [Click Here][1]

[1]: https://github.com/crisphuc/devops-todoapp-frontend/actions/runs/4158181816